### PR TITLE
Silence php notice with mongo-php-adapter

### DIFF
--- a/lib/phlask/TaskQueue/MongoQueue.php
+++ b/lib/phlask/TaskQueue/MongoQueue.php
@@ -155,7 +155,8 @@ class MongoQueue implements TaskQueueInterface
                 }
 
                 //update that we have taken this item off the queue and release the lock
-                $this->col->save($this->taskModel->updateAfterPopped($task));
+                $updatedTask = $this->taskModel->updateAfterPopped($task);
+                $this->col->save($updatedTask);
                 $this->releaseLock($id);
 
                 return $this->taskModel->createTaskFromModel($task);
@@ -177,8 +178,9 @@ class MongoQueue implements TaskQueueInterface
     protected function lock($taskId)
     {
         try {
+            $newLock = $this->taskLockModel->prepareInsert($taskId);
             $this->lock->insert(
-                $this->taskLockModel->prepareInsert($taskId),
+                $newLock,
                 array('w' => 1)//write must be acknowledged
             );
 


### PR DESCRIPTION
alcaeus/mongo-php-adapter is a dropin replacement for php mongo
extension for recent version of php. it allow to use ext-mongo like
ext-mongodb.

We use it to use phlask with php7, however, there are annoying notices
when running because lock->insert and col->save now take arguments by
reference rather than by value.
https://github.com/alcaeus/mongo-php-adapter/issues/107

This should silence the notices.